### PR TITLE
fix: add missing setup.sh for frontend container

### DIFF
--- a/async-code-web/setup.sh
+++ b/async-code-web/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# setup.sh - Frontend container setup script
+echo "🚀 Starting frontend container setup..."
+
+# Set environment to development if not already set
+export NODE_ENV=${NODE_ENV:-development}
+
+# Install dependencies
+echo "📦 Installing frontend dependencies..."
+npm install
+
+# Build the Next.js application
+echo "🔨 Building Next.js application..."
+npm run build
+
+# Start the development server
+echo "🌟 Starting Next.js development server..."
+echo "🎉 Frontend environment is ready!"
+
+# Start the Next.js application
+npm run dev


### PR DESCRIPTION
Fixes issue where frontend container reports "setup.sh: No such file or directory"

The issue was caused by Docker volume mapping in docker-compose.yml which  overwrites the setup.sh file copied during build.

- Added setup.sh file to async-code-web directory
- Tailored setup script for Next.js frontend application  
- Includes dependency installation, build, and dev server startup

Fixes #3